### PR TITLE
Draft: Web - Firebase Google Sign in and Sign out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ template/yarn.lock
 template/ios/Podfile.lock
 node_modules/
 yarn.lock
+.idea

--- a/template/src/app/auth-providers/Google.tsx
+++ b/template/src/app/auth-providers/Google.tsx
@@ -1,6 +1,6 @@
 import auth from '@react-native-firebase/auth';
 import {useContext, useEffect, useState} from 'react';
-import {Alert} from 'react-native';
+import {Alert, Platform} from 'react-native';
 import {FirebaseError} from '@firebase/util';
 import {
   GoogleSignin,
@@ -9,6 +9,7 @@ import {
 import {UserContext} from '../App';
 import ProviderButton from '../components/AuthProviderButton';
 import {getProviderButtonTitle} from '../util/helpers';
+import {signInWithPopup} from '../../shims/firebase-google-signin-web';
 
 const PROVIDER_ID = 'google.com';
 
@@ -88,7 +89,10 @@ function Google(): JSX.Element | null {
   }
 
   return (
-    <ProviderButton loading={loading} onPress={handleGoogle} type="google">
+    <ProviderButton
+      loading={loading}
+      onPress={Platform.OS === 'web' ? signInWithPopup : handleGoogle}
+      type="google">
       {title}
     </ProviderButton>
   );

--- a/template/src/app/signed-in/Settings.tsx
+++ b/template/src/app/signed-in/Settings.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react-native-paper';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import {useAppSettings} from '../AppSettings';
+import {signOutGoogle} from '../../shims/firebase-google-signin-web';
 
 function EditProfile(): JSX.Element | null {
   const user = auth().currentUser;
@@ -62,6 +63,7 @@ function EditProfile(): JSX.Element | null {
     setSigningOut(true);
     await GoogleSignin.signOut();
     await auth().signOut();
+    await signOutGoogle();
   }
 
   async function handleDisplayName() {

--- a/template/src/app/signed-out/SignIn.tsx
+++ b/template/src/app/signed-out/SignIn.tsx
@@ -51,7 +51,7 @@ function SignIn() {
         />
 
         {Platform.OS !== 'web' && <Facebook />}
-        {Platform.OS !== 'web' && <Google />}
+        <Google />
         {Platform.OS !== 'web' && <Apple />}
         <ProviderButton
           type="phone"

--- a/template/src/shims/firebase-google-signin-web.ts
+++ b/template/src/shims/firebase-google-signin-web.ts
@@ -1,0 +1,16 @@
+import {
+  getAuth,
+  GoogleAuthProvider,
+  signInWithPopup as signInWithPopupFirebase,
+  signOut as signOutFirebase,
+} from 'firebase/auth';
+
+import initializeApp from './firebase-init';
+initializeApp();
+
+const provider = new GoogleAuthProvider();
+provider.setCustomParameters({prompt: 'select_account'});
+const auth = getAuth();
+export const signInWithPopup = async () =>
+  await signInWithPopupFirebase(auth, provider);
+export const signOutGoogle = async () => await signOutFirebase(auth);


### PR DESCRIPTION
I'm not very experienced with Firebase, but I'm trying to figure out a nice way to integrate the rest of the sign in options for the web

I don't think we need any third party libraries to handle authorisations like Google SignIn. Firebase got us covered with everything we need in the browser. I also think it would be much easier than supporting react-native-google-signin for the web. (I tried it and I really don't appreciate the outcome)

I'm following this guide: https://firebase.google.com/docs/auth/web/google-signin and it seems to be working?