### PR TITLE
Bump ESLint to version 8

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -77,7 +77,7 @@
     "pod-install": "^0.1.32",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.5.1",
-    "react-scripts": "^4",
+    "react-scripts": "^5",
     "react-test-renderer": "^17.0.2",
     "typescript": "^4.6.2"
   },

--- a/template/package.json
+++ b/template/package.json
@@ -68,7 +68,7 @@
     "@types/react-test-renderer": "^17.0.1",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^5.13.0",
-    "eslint": "^7",
+    "eslint": "^8",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.29.2",
     "firebase-tools": "^10.2.2",


### PR DESCRIPTION
Other dependencies now require a higher version of ESLint. Without this dependency bump, we encounter the following error:
```
[simon@simon Consequences]$ npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: Consequences@0.0.1
npm ERR! Found: eslint@7.32.0
npm ERR! node_modules/eslint
npm ERR!   dev eslint@"^7" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer eslint@">=8" from @react-native-community/eslint-config@3.2.0
npm ERR! node_modules/@react-native-community/eslint-config
npm ERR!   dev @react-native-community/eslint-config@"^3.0.1" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /home/simon/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/simon/.npm/_logs/2023-03-09T11_35_21_865Z-debug-0.log
```